### PR TITLE
[FEAT]게이트웨이 호출 방식 수정

### DIFF
--- a/src/main/java/com/hulahoop/blueback/ai/controller/IntentController.java
+++ b/src/main/java/com/hulahoop/blueback/ai/controller/IntentController.java
@@ -3,12 +3,16 @@ package com.hulahoop.blueback.ai.controller;
 import com.hulahoop.blueback.ai.model.service.IntentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
 @RestController
 @RequestMapping("/api/intent")
 public class IntentController {
+
+    private static final Logger log = LoggerFactory.getLogger(IntentController.class);
 
     private final IntentService intentService;
 
@@ -21,6 +25,9 @@ public class IntentController {
     public ResponseEntity<Map<String, Object>> handleIntent(@RequestBody Map<String, Object> payload) {
         String intent = (String) payload.get("intent");
         Map<String, Object> data = (Map<String, Object>) payload.get("data");
+
+        log.info("intent: {}", intent);
+        log.info("data: {}", data);
 
         Map<String, Object> result = intentService.processIntent(intent, data);
         return ResponseEntity.ok(result);

--- a/src/main/java/com/hulahoop/blueback/config/AppConfig.java
+++ b/src/main/java/com/hulahoop/blueback/config/AppConfig.java
@@ -3,6 +3,7 @@ package com.hulahoop.blueback.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class AppConfig {
@@ -10,5 +11,10 @@ public class AppConfig {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate(); // RestTemplate 빈 등록
+    }
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
     }
 }


### PR DESCRIPTION
---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: "[PR] "
---

## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

스프링 클라우드 게이트웨이 방식으로 바뀐 저희 훌라후프 게이트웨이를 호출하기 위한 방식을 바꿔보았습니다.
기존의 intent 처리 방식은 내부 서비스 간 직접 호출 방식(혹은 RestTemplate) 기반으로 설계되어 확장성과 유연성이 떨어졌음.
이를 Spring WebFlux의 WebClient 기반 구조로 리팩토링하여 다음을 목표로 변경함:

서비스 간 완전한 비동기 통신

Spring Cloud Gateway를 통한 헤더 기반 동적 라우팅

공통 API 게이트웨이 경유 처리 (/api/gateway/dispatch)를 통한 일관된 요청 흐름

기존 로컬 서비스 내부 분기 처리 제거

WebClient.Builder를 주입받아 Gateway로 POST 요청 전송

요청 헤더에 intent, 바디는 {"intent": ..., "data": ...} 형태로 정규화

응답은 Mono<Map> → block() 사용으로 동기 처리 (향후 개선 여지 있음)

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

Postman 테스트에서 gateway → movie-service 분기 및 응답 정상

WebClient → Gateway → movie-service 연동 로깅 확인

null intent로 요청 시 명시적인 에러 반환 로직 동작

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

로그 기록 추가
<img width="2472" height="138" alt="image" src="https://github.com/user-attachments/assets/4c739c24-62b8-4ac2-847f-3e6102a7a7d9" />


## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
